### PR TITLE
Hotfix/2.7.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 
 language: R
 sudo: false
+cache: packages
 latex: false
 
 r:
@@ -11,4 +12,4 @@ r:
   - devel
 
 repos:
-  docker: http://r.docker.stat.auckland.ac.nz/R
+  docker: https://r.docker.stat.auckland.ac.nz

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,7 @@ Suggests:
     gridSVG,
     knitr,
     jsonlite
-Additional_repositories: http://r.docker.stat.auckland.ac.nz/R
+Additional_repositories: https://r.docker.stat.auckland.ac.nz
 Description: Simple plotting function(s) for exploratory data analysis with
     flexible plotting options to allow users to customise plots.
 License: GPL-3 | file LICENSE

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: iNZightPlots
 Type: Package
 Title: iNZightPlots
-Version: 2.7.9
-Date: 2018-08-14
+Version: 2.7.10
+Date: 2018-08-17
 Authors@R: c(person("Tom", "Elliott", role = c("aut", "cre"),
                     email = "tom.elliott@auckland.ac.nz"),
              person("Yu Han", "Soh", role = "ctb"))

--- a/NEWS.Md
+++ b/NEWS.Md
@@ -48,6 +48,8 @@ __Release date__: 23 March 2017
 - restructure templates dir into inst dir to make html/css/js templates accessible via `system.file()`
 - various other bug fixes and changes to interactive plots
 
+### Patch 2.7.10 - 17/08/2018
+- fix a bug in exportHTML where arguments not passed correctly
 
 ***
 # Version 2.6

--- a/R/exportHTML.R
+++ b/R/exportHTML.R
@@ -45,7 +45,7 @@ exportHTML.function <- function(x, file = 'index.html', data = NULL, local = FAL
 
   #do exporting:
   obj <- x()
-  url <- exportHTML(obj, file, data, extra.vars)
+  url <- exportHTML(obj, file, data = data, extra.vars = extra.vars)
 
   dev.off()
   setwd(curdir)


### PR DESCRIPTION
- pass arguments to `exportHTML.function()`
- use new repository URL