### PR TITLE
Fix percent issue with interactive one-way bar plots

### DIFF
--- a/R/exportHTML.R
+++ b/R/exportHTML.R
@@ -414,6 +414,8 @@ getInfo.inzbar <- function(plot, x) {
         tab[2,] <- paste0(tab[2,], "%")
         colnames(tab)[ncol(tab)] <- "Total"
         rownames(tab) <- c("Counts", "Percent")
+        
+        colnames(dt) <- c("othervar", "varx", "counts", "pct")
     }
 
     ## JSON:


### PR DESCRIPTION
One-way bar plots were showing `${count}%` (e.g. 229%) on the tooltips.