### PR TITLE
Fix bug in interactive sparkplot maps

### DIFF
--- a/NEWS.Md
+++ b/NEWS.Md
@@ -1,4 +1,5 @@
 - provide design effects for survey summaries
+- fix bug where regions cannot be selected in interactive sparkline plots due to id issue
 
 # iNZightPlots 2.11.4
 - fix bug that causes incorrect interactive map labels due to multipolygon regions 

--- a/inst/maps.js
+++ b/inst/maps.js
@@ -55,7 +55,8 @@ class Inzmap {
     d3.selectAll(this.pathElements)
       .attr("class", "region")
       .attr("id", (d, i) => {
-        return(data[n_polygons[i] - 1][names[0]] + "." + i);
+        let j = n_polygons[i] - 1;
+        return(data[j][names[0]] + "." + j);
       });
   }
 


### PR DESCRIPTION
Clicking a region or line would not select the region in the sparkline version.