### PR TITLE
Change gridSVG, knitr and jsonlite to dependencies from suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,14 +32,14 @@ Imports:
     iNZightTools (>= 1.9),
     rlang,
     magrittr,
-    lubridate
+    lubridate,
+    gridSVG (>= 1.7-2),
+    knitr,
+    jsonlite
 Suggests:
     hextri,
     viridis,
     RColorBrewer,
-    gridSVG (>= 1.7-2),
-    knitr,
-    jsonlite,
     testthat,
     covr,
     ggplot2,

--- a/R/exportHTML.R
+++ b/R/exportHTML.R
@@ -196,15 +196,6 @@ exportHTML.inzplotoutput <- function(x,
                                      dir = tempdir(),
                                      extra.vars = NULL, ...) {
 
-    #suggest gridSVG, jsonlite, xtable:
-    if( !requireNamespace("gridSVG",  quietly = TRUE) ||
-        !requireNamespace("knitr",   quietly = TRUE) ||
-        !requireNamespace("jsonlite", quietly = TRUE) ) {
-        stop(paste("Required packages aren't installed",
-                "Use 'install.packages('iNZightPlots', depends = TRUE)' to install them.",
-                sep = "\n"))
-    }
-
     x <- x
     plot <- x$all$all
 


### PR DESCRIPTION
The exportHTML method for inzplotoutput stops if the gridSVG, knitr and jsonlite packages are not installed, leading to interactive plots not functioning in iNZight by default -- recommend upgrading these from suggest to dependencies (import)