### PR TITLE
Add scale layer to ensure ggplot discrete scales match iNZightPlot

### DIFF
--- a/NEWS.Md
+++ b/NEWS.Md
@@ -1,5 +1,6 @@
 - add `ci.width` argument to `inzpar()` for plots and inferences for their confidence intervals
 - suppress warnings from `RColorBrewer::brewer.pal` if `n <= 2`
+- fix bug in ggplot2 plots where discrete axis ordering was different to a regular iNZightPlot (#270, @daniel-barnett)
 
 ## iNZightPlots 2.13.4
 

--- a/R/iNZGG.R
+++ b/R/iNZGG.R
@@ -465,6 +465,12 @@ iNZightPlotGG <- function(
   if (isTRUE(!is.null(caption) && caption != "")) {
     plot_exprs$plot <- rlang::expr(!!plot_exprs$plot + ggplot2::labs(caption = caption))
   }
+  
+  if (type %in% c("gg_barcode3", "gg_dotstrip", "gg_ridgeline")) {
+    plot_exprs$plot <- rlang::expr(!!plot_exprs$plot + ggplot2::scale_y_discrete(limits = rev))
+  } else if (type %in% c("gg_violin", "gg_boxplot", "gg_beeswarm", "gg_quasirandom")) {
+    plot_exprs$plot <- rlang::expr(!!plot_exprs$plot + ggplot2::scale_x_discrete(limits = rev))
+  }
 
   eval_env <- rlang::env(!!rlang::sym(data_name) := data)
 


### PR DESCRIPTION
This PR fixes #270 by adding an `scale_[x|y]_discrete` layer to the appropriate plots.