### PR TITLE
Stop putting fills on cumulative curve ggplots

### DIFF
--- a/R/iNZGG.R
+++ b/R/iNZGG.R
@@ -222,7 +222,7 @@ iNZightPlotGG_decide <- function(data, varnames, type, extra_vars) {
         } else {
           varnames["fill"] <- extra_vars$fill_colour
         }
-      } else {
+      } else if (type != "gg_cumcurve") {
         varnames["fill"] <- "darkgreen"
       }
     } else if (is.numeric(data[[varnames["x"]]])) {


### PR DESCRIPTION
Cumulative curve plots were getting a "darkgreen" fill applied which is not appropriate.